### PR TITLE
Add AMI for Seoul Region(ap-northeast-2)

### DIFF
--- a/course/system_operations/chef/chef-solo-admin-instance.json
+++ b/course/system_operations/chef/chef-solo-admin-instance.json
@@ -17,6 +17,9 @@
             "ap-northeast-1": {
                 "64": "ami-e74b60e6"
             },
+            "ap-northeast-2": {
+                "64": "ami-0500d06b"
+            },
             "ap-southeast-1": {
                 "64": "ami-d6e7c084"
             },


### PR DESCRIPTION
Hi folks,

I add AMI information for the Seoul Region (ap-northeast-2).
Please merge this PR.

Thanks a lot.